### PR TITLE
alguns ajustes no texto

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,8 +38,8 @@ makedocs(
     ),
     pages = [
         "Home" => "index.md",
-        "Complementary data" => "SystemsData.md",
-        "Supporting MDDFs and KBIs" => "SupportingCurves.md",
+        "Supplementary Tables" => "SystemsData.md",
+        "Supplementary Figures" => "SupportingCurves.md",
     ],
 )
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,12 +1,13 @@
 # Supporting Information for:  
 
+## Cation Hydrophobicity Effects on Protein Solvation in Aqueous Ionic Liquids
+
 ### Authors
 - **Vinicius Piccoli**¹
 - **Leandro Martínez**¹,*
 
 ¹Institute of Chemistry and Center for Computing in Engineering & Science, Universidade Estadual de Campinas (UNICAMP), 13083-861 Campinas, SP, Brazil
 
-### Corresponding Author
 *Leandro Martínez: lmartine@unicamp.br*  
 Institute of Chemistry, Universidade Estadual de Campinas (UNICAMP).  
 13083-970, Campinas, SP. Brazil  
@@ -15,7 +16,7 @@ Institute of Chemistry, Universidade Estadual de Campinas (UNICAMP).
 ---
 
 ### Description
-This repository contains supporting information and code for the paper _"Role of Imidazolium Cation Hydrophobicity in Ubiquitin Solvation by Aqueous Ionic Liquids"_. The data includes simulations, plots, and tables used for comparison between ionic liquids containing [EMIM]+ and [BMIM]+ cations and their interactions with various anions. The supporting figures and data tables are available below.
+This repository contains supporting information for the paper _"Cation Hydrophobicity Effects on Protein Solvation in Aqueous Ionic Liquids"_. 
 
 ---
 


### PR DESCRIPTION

Quando for gerar os HTMLs dos notebooks (pelo que vi não está fazendo isso automaticamente), preste atenção de ter expandido todas as tabelas. Agora, a última tabela não está acessível para quem entra no site.

Em paralelo: tenho um certo receio que este formato não seja permitido pelas revistas, por conta do copyright. Se não, vamos ter que criar um PDF. Dá para converter as tabelas para o googledocs fácil com:

```
using PrettyTables, DataFrames, CSV
df = CSV.read("./bulk_concentration_data.csv", DataFrame)
pretty_table(df; backend=Val(:markdown))
```

Isto gera um código markdown que pode ser copiado no GoogleDocs na forma de uma tabela direto. Acho que tem que ajustar uma prefencia para permitir markdown só.